### PR TITLE
Add mobile-friendly ability popup overlay

### DIFF
--- a/game.js
+++ b/game.js
@@ -81,10 +81,12 @@ class CardGame {
         this.abilityPopupClose = null;
         this.lastAbilityTrigger = null;
         this.handleAbilityKeydown = this.handleAbilityKeydown.bind(this);
+        this.displayScale = 'medium';
 
         this.initializeGame();
         this.setupEventListeners();
         this.setupAbilityPopup();
+        this.setupDisplayControls();
     }
 
     initializeGame() {
@@ -1000,6 +1002,63 @@ class CardGame {
                 this.aiDifficulty = e.target.dataset.difficulty;
                 this.log(`AI難易度を「${e.target.textContent}」に変更しました。`);
             });
+        });
+    }
+
+    setupDisplayControls() {
+        const displayButtons = document.querySelectorAll('.display-btn');
+        if (!displayButtons.length) {
+            return;
+        }
+
+        const storedScale = (() => {
+            try {
+                return localStorage.getItem('cardGameDisplayScale');
+            } catch (error) {
+                console.warn('画面サイズ設定を保存できませんでした。', error);
+                return null;
+            }
+        })();
+
+        const initialScale = ['small', 'medium', 'large'].includes(storedScale) ? storedScale : 'medium';
+        this.applyDisplayScale(initialScale);
+
+        displayButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                const scale = button.dataset.scale;
+                if (!scale) {
+                    return;
+                }
+
+                this.applyDisplayScale(scale);
+
+                try {
+                    localStorage.setItem('cardGameDisplayScale', scale);
+                } catch (error) {
+                    console.warn('画面サイズ設定を保存できませんでした。', error);
+                }
+            });
+        });
+    }
+
+    applyDisplayScale(scale) {
+        const validScales = ['small', 'medium', 'large'];
+        if (!validScales.includes(scale)) {
+            return;
+        }
+
+        validScales.forEach(value => {
+            document.body.classList.remove(`scale-${value}`);
+        });
+
+        document.body.classList.add(`scale-${scale}`);
+        this.displayScale = scale;
+
+        const buttons = document.querySelectorAll('.display-btn');
+        buttons.forEach(button => {
+            const isActive = button.dataset.scale === scale;
+            button.classList.toggle('active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -70,6 +70,16 @@
         </div>
     </div>
 
+    <div id="ability-popup" aria-hidden="true">
+        <div class="ability-popup-content" role="dialog" aria-modal="true" aria-labelledby="ability-popup-title">
+            <div class="ability-popup-header">
+                <h2 id="ability-popup-title">特殊能力</h2>
+                <button type="button" id="ability-popup-close" aria-label="閉じる">×</button>
+            </div>
+            <p id="ability-popup-text"></p>
+        </div>
+    </div>
+
     <script src="game.js?v=7"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,66 +7,77 @@
     <link rel="stylesheet" href="style.css?v=19">
 </head>
 <body>
-    <div id="game-container">
-        <!-- 難易度選択パネル -->
-        <div id="difficulty-panel">
-            <span class="difficulty-label">AI難易度:</span>
-            <button class="difficulty-btn" data-difficulty="easy">簡単</button>
-            <button class="difficulty-btn active" data-difficulty="normal">普通</button>
-            <button class="difficulty-btn" data-difficulty="hard">難しい</button>
-        </div>
+    <div id="game-wrapper">
+        <div id="game-container">
+            <div id="control-panels">
+                <!-- 難易度選択パネル -->
+                <div id="difficulty-panel">
+                    <span class="difficulty-label">AI難易度:</span>
+                    <button class="difficulty-btn" data-difficulty="easy">簡単</button>
+                    <button class="difficulty-btn active" data-difficulty="normal">普通</button>
+                    <button class="difficulty-btn" data-difficulty="hard">難しい</button>
+                </div>
 
-        <div id="game-board">
-            <!-- プレイヤー2エリア（上側） -->
-            <div class="player-area" id="player2-area">
-                <div class="player-info">
-                    <span class="player-name">プレイヤー2</span>
-                    <div class="player-stats">
-                        <span class="life">ライフ: <span id="player2-life">20</span></span>
-                        <span class="gems">ジェム: <span id="player2-gems">0</span></span>
-                        <span class="action">行動力: <span id="player2-action">0</span></span>
+                <div id="display-panel" role="group" aria-label="画面サイズ設定">
+                    <span class="display-label">画面サイズ:</span>
+                    <button type="button" class="display-btn" data-scale="small" aria-pressed="false">小</button>
+                    <button type="button" class="display-btn active" data-scale="medium" aria-pressed="true">標準</button>
+                    <button type="button" class="display-btn" data-scale="large" aria-pressed="false">大</button>
+                </div>
+            </div>
+
+            <div id="game-board">
+                <!-- プレイヤー2エリア（上側） -->
+                <div class="player-area" id="player2-area">
+                    <div class="player-info">
+                        <span class="player-name">プレイヤー2</span>
+                        <div class="player-stats">
+                            <span class="life">ライフ: <span id="player2-life">20</span></span>
+                            <span class="gems">ジェム: <span id="player2-gems">0</span></span>
+                            <span class="action">行動力: <span id="player2-action">0</span></span>
+                        </div>
+                    </div>
+                    <div class="hand" id="player2-hand">
+                        <!-- プレイヤー2の手札 -->
+                    </div>
+                    <div class="battlefield" id="player2-battlefield">
+                        <div class="field-slot" data-position="0"></div>
+                        <div class="field-slot" data-position="1"></div>
+                        <div class="field-slot" data-position="2"></div>
+                        <div class="field-slot" data-position="3"></div>
                     </div>
                 </div>
-                <div class="hand" id="player2-hand">
-                    <!-- プレイヤー2の手札 -->
-                </div>
-                <div class="battlefield" id="player2-battlefield">
-                    <div class="field-slot" data-position="0"></div>
-                    <div class="field-slot" data-position="1"></div>
-                    <div class="field-slot" data-position="2"></div>
-                    <div class="field-slot" data-position="3"></div>
-                </div>
-            </div>
 
-            <!-- ターンコントロール（中央） -->
-            <div id="turn-controls">
-                <button id="end-turn-btn">ターン終了</button>
-            </div>
+                <!-- ターンコントロール（中央） -->
+                <div id="turn-controls">
+                    <button id="end-turn-btn">ターン終了</button>
+                </div>
 
-            <!-- プレイヤー1エリア（下側） -->
-            <div class="player-area" id="player1-area">
-                <div class="battlefield" id="player1-battlefield">
-                    <div class="field-slot" data-position="0"></div>
-                    <div class="field-slot" data-position="1"></div>
-                    <div class="field-slot" data-position="2"></div>
-                    <div class="field-slot" data-position="3"></div>
-                </div>
-                <div class="hand" id="player1-hand">
-                    <!-- プレイヤー1の手札 -->
-                </div>
-                <div class="player-info">
-                    <span class="player-name">プレイヤー1</span>
-                    <div class="player-stats">
-                        <span class="life">ライフ: <span id="player1-life">20</span></span>
-                        <span class="gems">ジェム: <span id="player1-gems">0</span></span>
-                        <span class="action">行動力: <span id="player1-action">1</span></span>
+                <!-- プレイヤー1エリア（下側） -->
+                <div class="player-area" id="player1-area">
+                    <div class="battlefield" id="player1-battlefield">
+                        <div class="field-slot" data-position="0"></div>
+                        <div class="field-slot" data-position="1"></div>
+                        <div class="field-slot" data-position="2"></div>
+                        <div class="field-slot" data-position="3"></div>
+                    </div>
+                    <div class="hand" id="player1-hand">
+                        <!-- プレイヤー1の手札 -->
+                    </div>
+                    <div class="player-info">
+                        <span class="player-name">プレイヤー1</span>
+                        <div class="player-stats">
+                            <span class="life">ライフ: <span id="player1-life">20</span></span>
+                            <span class="gems">ジェム: <span id="player1-gems">0</span></span>
+                            <span class="action">行動力: <span id="player1-action">1</span></span>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
 
-        <div id="game-log">
-            <div id="log-content"></div>
+            <div id="game-log">
+                <div id="log-content"></div>
+            </div>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -336,21 +336,68 @@ body {
     color: rgba(255, 255, 255, 0.6);
 }
 
+.ability-trigger {
+    cursor: pointer;
+    font-family: inherit;
+    touch-action: manipulation;
+}
+
+.ability-trigger:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.9);
+    outline-offset: 2px;
+}
+
 .card-ability {
     position: absolute;
     top: 2px;
     right: 2px;
     font-size: 12px;
-    cursor: help;
+    border: none;
+    background: rgba(255, 255, 255, 0.1);
+    color: #ffd700;
     filter: drop-shadow(0 0 2px rgba(255, 215, 0, 0.8));
+    padding: 4px;
+    border-radius: 999px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.card-ability:hover,
+.card-ability:focus-visible {
+    background: rgba(255, 215, 0, 0.3);
+    transform: scale(1.1);
 }
 
 .monster-ability {
-    font-size: 7px;
-    margin-top: 2px;
-    opacity: 0.9;
-    font-weight: normal;
+    margin-top: 6px;
+    font-size: 9px;
+    opacity: 0.95;
+    font-weight: bold;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    border: none;
+    background: rgba(255, 255, 255, 0.18);
+    color: #ffffff;
+    padding: 4px 10px;
+    border-radius: 999px;
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.monster-ability::after {
+    content: '\2139';
+    font-size: 10px;
+}
+
+.monster-ability:hover,
+.monster-ability:focus-visible {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateY(-1px);
 }
 
 .battlefield {
@@ -421,6 +468,7 @@ body {
     animation: cardSummon 0.5s ease-out;
     position: relative;
     overflow: hidden;
+    gap: 4px;
 }
 
 .monster::before {
@@ -607,6 +655,7 @@ body {
         font-size: 10px;
         top: 1px;
         right: 1px;
+        padding: 3px;
     }
 
     .battlefield {
@@ -638,8 +687,9 @@ body {
     }
 
     .monster-ability {
-        font-size: 6px;
-        margin-top: 1px;
+        font-size: 7px;
+        padding: 3px 8px;
+        margin-top: 4px;
     }
 
     #game-log {
@@ -699,6 +749,96 @@ body {
 
     .monster-stats {
         font-size: 9px;
+    }
+
+    .monster-ability {
+        font-size: 7px;
+        padding: 3px 8px;
+    }
+}
+
+body.ability-popup-open {
+    overflow: hidden;
+}
+
+#ability-popup {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: none;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 24px 16px 32px;
+    z-index: 999;
+    backdrop-filter: blur(2px);
+}
+
+#ability-popup.active {
+    display: flex;
+}
+
+.ability-popup-content {
+    background: rgba(255, 255, 255, 0.97);
+    border-radius: 16px;
+    padding: 20px 20px 24px;
+    width: 100%;
+    max-width: 360px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.25);
+    border: 2px solid rgba(255, 255, 255, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    animation: slideUp 0.25s ease-out;
+}
+
+.ability-popup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.ability-popup-header h2 {
+    font-size: 18px;
+    color: #2d3748;
+}
+
+#ability-popup-close {
+    border: none;
+    background: rgba(237, 242, 247, 0.9);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    color: #4a5568;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+#ability-popup-close:hover,
+#ability-popup-close:focus-visible {
+    background: rgba(160, 174, 192, 0.9);
+    color: white;
+    transform: scale(1.05);
+}
+
+#ability-popup-text {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #2d3748;
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -4,6 +4,22 @@
     box-sizing: border-box;
 }
 
+:root {
+    --ui-scale: 1;
+}
+
+body.scale-small {
+    --ui-scale: 0.85;
+}
+
+body.scale-medium {
+    --ui-scale: 1;
+}
+
+body.scale-large {
+    --ui-scale: 1.15;
+}
+
 @keyframes gradientShift {
     0% { background-position: 0% 50%; }
     50% { background-position: 100% 50%; }
@@ -37,6 +53,14 @@ body {
     overflow-y: auto;
 }
 
+#game-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    padding: 12px 8px 20px;
+    overflow-x: auto;
+}
+
 #game-container {
     padding: 8px;
     display: flex;
@@ -44,6 +68,18 @@ body {
     gap: 8px;
     max-width: 1200px;
     margin: 0 auto;
+    transform-origin: top center;
+    transform: scale(var(--ui-scale));
+    transition: transform 0.25s ease;
+    will-change: transform;
+}
+
+#control-panels {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
 }
 
 #difficulty-panel {
@@ -57,6 +93,12 @@ body {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     border: 2px solid rgba(255, 255, 255, 0.5);
     backdrop-filter: blur(10px);
+}
+
+#difficulty-panel,
+#display-panel {
+    flex: 1 1 260px;
+    min-width: 200px;
 }
 
 .difficulty-label {
@@ -87,6 +129,51 @@ body {
     color: white;
     border-color: #667eea;
     box-shadow: 0 4px 8px rgba(102, 126, 234, 0.3);
+}
+
+#display-panel {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 12px;
+    padding: 8px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(10px);
+}
+
+.display-label {
+    font-weight: bold;
+    color: #2d3748;
+    font-size: 14px;
+}
+
+.display-btn {
+    padding: 6px 16px;
+    border: 2px solid #cbd5e0;
+    border-radius: 8px;
+    background: white;
+    color: #4a5568;
+    font-weight: bold;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-size: 13px;
+    touch-action: manipulation;
+}
+
+.display-btn:hover,
+.display-btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.display-btn.active {
+    background: linear-gradient(135deg, #f6ad55 0%, #f97316 100%);
+    color: white;
+    border-color: #f97316;
+    box-shadow: 0 4px 8px rgba(249, 115, 22, 0.3);
 }
 
 #turn-info {
@@ -572,8 +659,16 @@ body {
         font-size: 14px;
     }
 
+    #game-wrapper {
+        padding: 8px 4px 16px;
+    }
+
     #game-container {
         padding: 4px;
+        gap: 6px;
+    }
+
+    #control-panels {
         gap: 6px;
     }
 
@@ -583,6 +678,17 @@ body {
         flex-wrap: wrap;
     }
 
+    #display-panel {
+        padding: 6px 8px;
+        gap: 4px;
+        flex-wrap: wrap;
+    }
+
+    #difficulty-panel,
+    #display-panel {
+        min-width: 160px;
+    }
+
     .difficulty-label {
         font-size: 12px;
         width: 100%;
@@ -590,6 +696,18 @@ body {
     }
 
     .difficulty-btn {
+        padding: 4px 12px;
+        font-size: 11px;
+        flex: 1;
+    }
+
+    .display-label {
+        font-size: 12px;
+        width: 100%;
+        text-align: center;
+    }
+
+    .display-btn {
         padding: 4px 12px;
         font-size: 11px;
         flex: 1;
@@ -710,12 +828,30 @@ body {
 }
 
 @media (max-width: 480px) {
+    #game-wrapper {
+        padding: 6px 2px 14px;
+    }
+
     #game-container {
         padding: 2px;
         gap: 4px;
     }
 
+    #control-panels {
+        gap: 4px;
+    }
+
     .difficulty-btn {
+        padding: 3px 8px;
+        font-size: 10px;
+    }
+
+    #display-panel {
+        padding: 5px 6px;
+        gap: 3px;
+    }
+
+    .display-btn {
         padding: 3px 8px;
         font-size: 10px;
     }


### PR DESCRIPTION
## Summary
- add a modal popup so tapping ability icons on mobile reveals full text
- restyle ability icons for touch interaction and add a dedicated close button
- ensure new popup styling and layout integrate with existing responsive styles

## Testing
- manual testing: opened http://127.0.0.1:8000/index.html, tapped ability icon on mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_6906fbc4df2c8327befa51250229096c