### PR TITLE
UI: remove HP/ATK labels and enlarge card stat numbers

### DIFF
--- a/game.js
+++ b/game.js
@@ -477,12 +477,12 @@ class CardGame {
             cardElement.innerHTML = `
                 <div class="card-name">
                     <span class="card-name-text">${card.name}</span>
-                    <span class="card-cost">[${card.cost}]</span>
+                    <span class="card-cost">${card.cost}</span>
                 </div>
                 <img class="card-image" src="${this.getCardImagePath(card.name)}" alt="${card.name}">
                 <div class="card-stats">
-                    <span>HP:${card.hp}</span>
-                    <span>ATK:${card.attack}</span>
+                    <span class="stat-value">${card.hp}</span>
+                    <span class="stat-value">${card.attack}</span>
                 </div>
             `;
 
@@ -510,8 +510,8 @@ class CardGame {
                     <div class="monster-name">${monster.name}</div>
                     <img class="monster-image" src="${this.getCardImagePath(monster.name)}" alt="${monster.name}">
                     <div class="monster-stats">
-                        <span>HP: ${monster.hp}/${monster.maxHp}</span>
-                        <span>ATK: ${monster.attack}</span>
+                        <span>${monster.hp}/${monster.maxHp}</span>
+                        <span>${monster.attack}</span>
                     </div>
                 `;
                 

--- a/style.css
+++ b/style.css
@@ -187,7 +187,7 @@ body {
     margin-bottom: 2px;
     color: white;
     gap: 3px;
-    font-size: 9px;
+    font-size: 10px;
 }
 
 .card-name-text {
@@ -195,7 +195,9 @@ body {
 }
 
 .card-cost {
-    font-size: 8px;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1;
     color: #e2e8f0;
     flex: 0 0 auto;
 }
@@ -205,7 +207,8 @@ body {
     justify-content: center;
     align-items: center;
     gap: 4px;
-    font-size: 7px;
+    font-size: 13px;
+    font-weight: 700;
     color: white;
     flex-wrap: wrap;
 }
@@ -225,6 +228,10 @@ body {
     content: '/';
     margin-right: 4px;
     color: rgba(255, 255, 255, 0.6);
+}
+
+.card-stats .stat-value {
+    font-variant-numeric: tabular-nums;
 }
 
 .battlefield {
@@ -300,7 +307,7 @@ body {
 .monster-stats {
     display: flex;
     justify-content: space-around;
-    font-size: 9px;
+    font-size: 12px;
     font-weight: bold;
 }
 


### PR DESCRIPTION
### Motivation
- Improve visual balance and readability of card UI by emphasizing numeric values and reducing redundant labels.
- Make cost and stat figures more prominent so players can quickly scan cards in hand and on the battlefield.

### Description
- Removed textual `HP:` / `ATK:` labels from hand card and battlefield monster stat displays so only numeric values are shown (`game.js` updated to output numbers only).
- Simplified cost display from bracketed form (`[3]`) to plain numeric (`3`) in the hand card template (`game.js`).
- Increased typography for cost and stat numbers by enlarging font size and weight, adjusted card name sizing, and made monster stat text larger (`style.css`).
- Added `font-variant-numeric: tabular-nums` for stat values to keep digit widths consistent (`style.css`).

### Testing
- Ran `node --check game.js` and it succeeded.
- Started a local static server with `python3 -m http.server 4173` and loaded the app in a headless browser to verify layout, which responded successfully.
- Captured a screenshot via Playwright (`page.screenshot`) showing the updated UI layout for visual validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b158434083278c6dce828da2f3e0)