### PR TITLE
盤面のモンスターアイコンを見やすく拡大

### DIFF
--- a/style.css
+++ b/style.css
@@ -307,7 +307,7 @@ body {
 
 .monster-image {
     width: 100%;
-    height: 24px;
+    height: 30px;
     object-fit: contain;
     margin-bottom: 2px;
 }


### PR DESCRIPTION
### Motivation
- 盤面上のモンスターアイコンの視認性を向上させるため、表示サイズをわずかに拡大しました。

### Description
- `style.css` の `.monster-image` の `height` を `24px` から `30px` に変更しました（ファイル: `style.css`）。

### Testing
- ローカルで `python3 -m http.server 4173` を起動し、Playwrightによるスクリーンショット取得を行って表示を確認したところ、アイコンが拡大されていることを確認でき、コマンドは正常終了しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992b7a089b4832795d4b535963a4540)