### PR TITLE
Expand battlefield layout to better use board space on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>カードゲーム</title>
-    <link rel="stylesheet" href="style.css?v=22">
+    <link rel="stylesheet" href="style.css?v=23">
 </head>
 <body>
     <div id="game-container">

--- a/style.css
+++ b/style.css
@@ -243,12 +243,11 @@ body {
 
 .battlefield {
     display: grid;
-    grid-template-columns: repeat(2, 90px);
-    grid-template-rows: repeat(2, 60px);
-    gap: 1px;
-    margin-bottom: 8px;
-    height: 121px;
-    justify-content: center;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    margin: 0 auto 8px;
+    width: 100%;
+    max-width: 360px;
 }
 
 /* プレイヤー2（相手）の盤面は前列と後列を入れ替え */
@@ -264,8 +263,9 @@ body {
 #player2-battlefield .field-slot[data-position="3"] { grid-area: back-right; }
 
 .field-slot {
-    width: 90px;
-    height: 60px;
+    width: 100%;
+    min-height: 72px;
+    aspect-ratio: 3 / 2;
     border: 2px dashed #cbd5e0;
     border-radius: 8px;
     display: flex;


### PR DESCRIPTION
### Motivation
- Mobile/compact layouts were constrained by fixed 90×60px battlefield cells, limiting usable horizontal space on small screens.
- The goal is to make the battlefield fill more of the available width while keeping slot shapes stable.

### Description
- Reworked `.battlefield` from fixed pixel tracks to responsive two-column layout using `grid-template-columns: repeat(2, minmax(0, 1fr))` and constrained it with `width: 100%` and `max-width: 360px` in `style.css`.
- Increased inter-slot spacing via `gap: 6px` and centered the battlefield with `margin: 0 auto 8px` in `style.css`.
- Updated `.field-slot` to `width: 100%`, `min-height: 72px` and `aspect-ratio: 3 / 2` so slots expand naturally without distorting content.
- Bumped the stylesheet cache-buster query in `index.html` to ensure clients pick up the new CSS.

### Testing
- Served the site with `python -m http.server` and verified the server responded successfully via `curl -I`, which returned `HTTP/1.0 200 OK`.
- Captured a mobile-viewport screenshot using Playwright (WebKit) to validate the updated layout visually, which completed successfully and produced an artifact image.
- Reviewed the CSS diff locally to confirm the intended changes were applied and there were no unexpected edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b4d92e348327ae727b786a1b3d83)