### PR TITLE
Tighten mobile battlefield card spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,6 +13,8 @@ body {
 }
 
 #game-container {
+    width: min(100%, 960px);
+    margin: 0 auto;
     padding: 8px;
     display: flex;
     flex-direction: column;
@@ -247,7 +249,7 @@ body {
     gap: 6px;
     margin: 0 auto 8px;
     width: 100%;
-    max-width: 360px;
+    max-width: 100%;
 }
 
 /* プレイヤー2（相手）の盤面は前列と後列を入れ替え */
@@ -400,5 +402,57 @@ body {
     #end-turn-btn {
         animation: none !important;
         transition: none !important;
+    }
+}
+
+@media (max-width: 768px) {
+    #game-container {
+        padding: 10px;
+        gap: 8px;
+    }
+
+    .player-area {
+        padding: 10px 10px 8px;
+        gap: 8px;
+    }
+
+    .hand {
+        gap: 6px;
+    }
+
+    .card {
+        width: calc((100vw - 52px) / 4) !important;
+        min-width: 80px;
+        max-width: 98px;
+        height: clamp(88px, 24vw, 110px) !important;
+    }
+
+    .card-image {
+        height: clamp(34px, 10vw, 44px);
+    }
+
+    .battlefield {
+        gap: 8px;
+    }
+
+    .field-slot {
+        min-height: 76px;
+        aspect-ratio: 3 / 2;
+    }
+
+    .monster {
+        padding: 6px 8px;
+        justify-content: center;
+        gap: 6px;
+    }
+
+    .monster-image {
+        height: clamp(28px, 9vw, 38px);
+        margin-bottom: 0;
+    }
+
+    .monster-stats {
+        font-size: 14px;
+        line-height: 1;
     }
 }


### PR DESCRIPTION
### Motivation
- Address an inline report that battlefield cards had excessive internal whitespace on mobile and make the board feel less cramped and more balanced on small viewports.
- Preserve earlier mobile layout improvements that allow the main container to expand and center on narrow screens.

### Description
- Add `width: min(100%, 960px)` and `margin: 0 auto` to `#game-container` and set `.battlefield` `max-width` to `100%` so the layout can expand and remain centered on small screens.
- Add an `@media (max-width: 768px)` block that tightens mobile spacing by reducing `.field-slot` `min-height` to `76px` and using `aspect-ratio: 3 / 2` so slots no longer create oversized containers.
- Make battlefield cards denser by reducing `.monster` padding to `6px 8px`, centering content with `justify-content: center` and adding a controlled `gap`, and scale the `.monster-image` down with `height: clamp(28px, 9vw, 38px)`.
- Improve text density inside cards by adding `.monster-stats` font sizing and line-height, and adjust mobile `.card` sizing, `.player-area`, and `.hand` gaps for consistent balance.

### Testing
- Ran `git diff --check` which returned no issues.
- Served the site locally with `python3 -m http.server 4173` and confirmed assets load in the browser.
- Captured a mobile viewport screenshot (390x844) with Playwright using Firefox and saved to `artifacts/mobile-balance-tightened-board-card.png` which verifies the tighter spacing visually.
- Playwright Chromium screenshot attempt failed due to an environment-level browser crash, unrelated to the CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999be1413d08327a0bedcd9630b2b38)